### PR TITLE
Log all jsDomErrors when using the default jsdom testEnvironment in jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
       "ts",
       "tsx",
       "js"
-    ]
+    ],
+    "setupTestFrameworkScriptFile": "<rootDir>/src/jest/setup.js"
   },
   "scripts": {
     "lint:sass": "sass-lint src/**/*.scss -v --max-warnings 1",

--- a/src/jest/setup.js
+++ b/src/jest/setup.js
@@ -1,0 +1,4 @@
+// Log all jsDomErrors when using jsdom testEnvironment
+window._virtualConsole && window._virtualConsole.on('jsdomError', function (error) {
+  console.error('jsDomError', error.stack, error.detail);
+});


### PR DESCRIPTION
- this is useful in finding the root cause of a failure
  - for example CORS errors get reported as jsDomError events